### PR TITLE
feat-update-images

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -202,7 +202,7 @@ jobs:
     steps:
       - name: Trigger workrave-infra image update
         run: |
-          curl -X POST \
+          curl --fail-with-body -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.INFRA_DISPATCH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -193,3 +193,18 @@ jobs:
             --yes \
             --predicate <(echo '{"buildType":"github-actions","builder":{"id":"https://github.com/${{ github.repository }}/.github/workflows/containers.yml@refs/heads/${{ github.ref_name || github.ref_name }}"}}') \
             ${IMAGE}:latest
+
+  update-infra:
+    name: Update development images in workrave-infra
+    runs-on: ubuntu-24.04
+    needs: create-and-sign-manifests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Trigger workrave-infra image update
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.INFRA_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/rcaelers/workrave-infra/dispatches \
+            -d '{"event_type":"update-dev-images","client_payload":{"sha":"${{ github.sha }}","services":"api processor curator ingestion"}}'

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -174,9 +174,9 @@ ingestion_server:
     Qeqd8A0LJGwWC2dOVwmV06aN/txAvVPEG5KDJkJ6hLzi2BK+zpHz7RpnWn/H6Bgi
     kH89+JqlOvmRo8PEP2GF/hiNjlwfzwg=
     -----END PRIVATE KEY-----
-job_server:
-  port: 88
-  redis_uri: redis://localhost:6379
+valkey:
+  uri: redis://localhost:6379
+processor:
   maximum_frame_count: 10
   delimiter: "|"
   skip_patterns:


### PR DESCRIPTION
- [x] Add `--fail-with-body` flag to `curl` command in `update-infra` job so the workflow fails on HTTP 4xx/5xx responses from the GitHub dispatch API